### PR TITLE
Fix "ArrayIndexOutOfBounds" error in random-player.js.

### DIFF
--- a/scripts/random-player.js
+++ b/scripts/random-player.js
@@ -9,7 +9,7 @@ export default class RandomPlayer extends HTMLElement {
     return ['28012031', '26379178', '1831600483'];
   }
   get randomMusicId() {
-    return this.ids[Math.floor(Math.random() * (this.ids.length + 1))];
+    return this.ids[Math.floor(Math.random() * this.ids.length)];
   }
   constructor() {
     super();


### PR DESCRIPTION
Fix #35 

This bug causes "undefine" in the music url.

