### PR TITLE
【小修补】将移动端萌娘链接统一改为桌面版

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -91,7 +91,7 @@
           <ul>
             <li>
               上条当麻（Kamijo Touma）：抹杀一切非自然力量的<a
-                href="https://mzh.moegirl.org.cn/幻想杀手"
+                href="https://zh.moegirl.org.cn/幻想杀手"
                 target="_blank"
                 >幻想杀手</a
               >，御坂美琴在与他进行了一次小规模斗争后对其产生一些好感（认为上条把自己当作普通人看待）。
@@ -117,7 +117,7 @@
             </li>
             <li>
               一方通行（Accelerator）：Level-5第一位，和御坂美琴曾是敌人，唯一有资质安全晋升成为
-              <a href="https://mzh.moegirl.org.cn/绝对能力者" target="_blank"> 绝对能力者 </a>
+              <a href="https://zh.moegirl.org.cn/绝对能力者" target="_blank"> 绝对能力者 </a>
               的人。御坂美琴在一方通行参加进化试验期间，为了营救妹妹们和其战斗，但最终失败。
             </li>
           </ul>

--- a/pages/about-railgun/index.html
+++ b/pages/about-railgun/index.html
@@ -52,7 +52,7 @@
       <h3>人际关系</h3>
       <ul>
         <li>
-          上条当麻（Kamijo Touma）：抹杀一切非自然力量的<a href="https://mzh.moegirl.org.cn/幻想杀手" target="_blank"
+          上条当麻（Kamijo Touma）：抹杀一切非自然力量的<a href="https://zh.moegirl.org.cn/幻想杀手" target="_blank"
             >幻想杀手</a
           >，御坂美琴在与他进行了一次小规模斗争后对其产生一些好感（认为上条把自己当作普通人看待）。
         </li>
@@ -76,7 +76,7 @@
         </li>
         <li>
           一方通行（Accelerator）：Level-5第一位，和御坂美琴曾是敌人，唯一有资质安全晋升成为
-          <a href="https://mzh.moegirl.org.cn/绝对能力者" target="_blank"> 绝对能力者 </a>
+          <a href="https://zh.moegirl.org.cn/绝对能力者" target="_blank"> 绝对能力者 </a>
           的人。御坂美琴在一方通行参加进化试验期间，为了营救妹妹们和其战斗，但最终失败。
         </li>
       </ul>


### PR DESCRIPTION
同学在班群里发了这个链接，出于好奇点进来看了看。本人不是超炮和炮姐厨。

浏览页面的时候发现关于页上，有两个链接都是指向移动端萌娘百科的。诚然这没什么大问题，但是如果改成桌面端的话应该会更好，这样可以同时适配桌面和移动端两种设备。

（注：用 Google Chrome 的 DevTools 试了一下，[萌娘百科主页](https://zh.moegirl.org.cn/Mainpage) 在使用 Devtools 的**设备模拟**时，能够用默认配置的移动设备正确跳转到移动版主页。）

（注2：实验版和普通版均已同步更改，如考虑合并的话可放心合并。）

只是路过提一个小建议而已，谢谢。😊